### PR TITLE
chore(hosted vm): fly.io updated (#28)

### DIFF
--- a/redirection-service/fly.toml
+++ b/redirection-service/fly.toml
@@ -14,10 +14,9 @@ primary_region = 'ord'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ['app']
 
 [[vm]]
-  memory = '1gb'
-  cpu_kind = 'shared'
-  cpus = 2
+  size = "shared-cpu-1x"
+  memory = "1gb"

--- a/shortening-service/fly.toml
+++ b/shortening-service/fly.toml
@@ -11,10 +11,11 @@ primary_region = 'ord'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = false
+  auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ['app']
 
 [[vm]]
-  size = 'shared-cpu-2x'
+  size = "shared-cpu-1x"
+  memory = "1gb"


### PR DESCRIPTION
* Shrink VM to shared-cpu-1x:256mb + keep auto-stop

* Shrink VM to shared-cpu-1x:256mb + keep auto-stop

* chore(docker hosting): fly.io update